### PR TITLE
Adds externs to the compiler

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,3 +1,4 @@
+lein clean
 lein cljsbuild once min
 firebase login
 firebase deploy

--- a/externs/firebase.js
+++ b/externs/firebase.js
@@ -1,0 +1,7 @@
+var firebase = {};
+firebase.initializeApp = function(){};
+firebase.auth = function(){};
+firebase.auth.GoogleAuthProvider = function(){};
+firebase.auth.signInWithPopup = function(){};
+firebase.auth.signOut = function(){};
+firebase.auth.onAuthStateChanged = function(){};

--- a/project.clj
+++ b/project.clj
@@ -45,9 +45,8 @@
                     :output-to       "public/js/compiled/app.js"
                     :optimizations   :advanced
                     :closure-defines {goog.DEBUG false}
-                    :pretty-print    false}}
-
-
+                    :pretty-print    false
+                    :externs ["externs/firebase.js"]}}
     ]}
 
   )

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <script src="https://www.gstatic.com/firebasejs/4.9.0/firebase.js"></script>
     <script src="https://www.gstatic.com/firebasejs/4.9.0/firebase-app.js"></script>
     <script src="https://www.gstatic.com/firebasejs/4.9.0/firebase-auth.js"></script>
-    <script src="js/compiled/app.js">
-        coffeepot.core.init();</script>
+    <script src="js/compiled/app.js"></script>
+    <script>coffeepot.core.init();</script>
   </body>
 </html>


### PR DESCRIPTION
This allows us to tell the production compiler not to minify
firebase external libraries function and variables.
These are specified in the externs/firebase.js file.

So for future reference: If you want to interop external
javascript libraries in clojurescript, you need to use
them this way.