### PR TITLE
Adds tongue localization library

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
                  [com.andrewmcveigh/cljs-time "0.5.0"]
                  [org.clojure/core.async "0.2.391"]
                  [re-com "2.1.0"]
-                 [re-frisk "0.5.3"]]
+                 [re-frisk "0.5.3"]
+                 [tongue "0.2.3"]]
 
   :plugins [[lein-cljsbuild "1.1.5"]]
 

--- a/src/cljs/coffeepot/app.cljs
+++ b/src/cljs/coffeepot/app.cljs
@@ -4,7 +4,8 @@
             [coffeepot.subs :as subs]
             [coffeepot.events :as events]
             [coffeepot.components.common :as c]
-            [coffeepot.views.coffee.core :as coffee]))
+            [coffeepot.views.coffee.core :as coffee]
+            [coffeepot.localization :refer [localize-with-substitute]]))
 
 (defn provider []
   (new js/firebase.auth.GoogleAuthProvider))
@@ -48,8 +49,18 @@
                  [c/header-brand-item
                   [c/title "Coffeepot"]]]]
                [c/header-section
+                [c/header-item 
+                 [:img {:src "https://lipis.github.io/flag-icon-css/flags/1x1/fi.svg" 
+                  :height "20px" 
+                  :width "20px"
+                  :on-click (fn [] (re-frame/dispatch [::events/change-locale :fi]))}]]
+                [c/header-item 
+                 [:img {:src "https://lipis.github.io/flag-icon-css/flags/1x1/gb.svg" 
+                  :height "20px" 
+                  :width "20px"
+                  :on-click (fn [] (re-frame/dispatch [::events/change-locale :en]))}]]
                 [c/header-item
-                 [c/button "Login with Google" (fn login-click [e]
+                 [c/button (localize-with-substitute :login "Google") (fn login-click [e]
                                                  (google-sign-in))]]]]
               [c/content
                [c/phone-preview-box

--- a/src/cljs/coffeepot/db.cljs
+++ b/src/cljs/coffeepot/db.cljs
@@ -5,4 +5,5 @@
    :firebase-app nil
    :auth-listener false
    :user {:username "User Name"
-          :logged-in false}})
+          :logged-in false}
+   :locale :fi})

--- a/src/cljs/coffeepot/events.cljs
+++ b/src/cljs/coffeepot/events.cljs
@@ -17,6 +17,11 @@
  (fn [db  [_ logged-in]]
    (assoc-in db [:user :logged-in] logged-in)))
 
+(re-frame/reg-event-db
+ ::change-locale
+ (fn [db  [_ locale]]
+   (assoc db :locale locale)))
+
 (def firebase-config
    #js {:apiKey "AIzaSyABjP8bTTvEfy1n_pgR8oiqFBCn6hr4CP8"
         :authDomain "coffeepot-d13ea.firebaseapp.com"

--- a/src/cljs/coffeepot/localization.cljs
+++ b/src/cljs/coffeepot/localization.cljs
@@ -1,0 +1,30 @@
+(ns coffeepot.localization
+    (:require [tongue.core :as tongue]
+              [re-frame.core :refer [subscribe]]
+              [coffeepot.subs :as subs]))
+
+(def dictionary {
+    :fi {
+        :login "Kirjaudu sisään {1}:lla"
+        :logout "Kirjaudu ulos"
+    }
+    :en 
+    {
+        :login "Login with {1}"
+        :logout "Logout"
+    }
+    :tongue/fallback :fi
+})
+
+(def translate
+  (tongue/build-translate dictionary))
+
+(defn localize [text-key]
+    (let [locale (subscribe [::subs/locale])]
+        (translate @locale text-key))
+)
+
+(defn localize-with-substitute [text-key substitution]
+    (let [locale (subscribe [::subs/locale])]
+        (translate @locale text-key substitution))
+)

--- a/src/cljs/coffeepot/subs.cljs
+++ b/src/cljs/coffeepot/subs.cljs
@@ -20,3 +20,8 @@
  ::user
  (fn [db]
    (:user db)))
+
+(re-frame/reg-sub
+ ::locale
+ (fn [db]
+   (:locale db)))

--- a/src/cljs/coffeepot/views/coffee/core.cljs
+++ b/src/cljs/coffeepot/views/coffee/core.cljs
@@ -3,7 +3,8 @@
             [re-com.core :as re-com]
             [coffeepot.components.common :as c]
             [coffeepot.events :as events]
-            [coffeepot.subs :as subs]))
+            [coffeepot.subs :as subs]
+            [coffeepot.localization :refer [localize]]))
 
 (defn logout-auth []
   (println "logging out")
@@ -44,7 +45,7 @@
                         ["Paulig" "Juhla Mokka" "Brazil" "Kulta Katriina"])]]]
                    [c/header-section
                     [c/header-item
-                     [c/button "Logout" (fn login-click [e]
+                     [c/button (localize :logout) (fn login-click [e]
                                       (logout-auth))]]]]
                   [c/app-content
                    [:p (str "Hei käyttäjä " (:username @user))]]]])))


### PR DESCRIPTION
Replaces "Login with Google" with a localized text from the
localization file with an example on substitution.

The same login localized text could now be paired with
Google or Facebook for example. Might be useful.