### PR TITLE
Moves all firebase related methods and configs into a separate namespace

### DIFF
--- a/src/cljs/coffeepot/app.cljs
+++ b/src/cljs/coffeepot/app.cljs
@@ -15,6 +15,8 @@
             [coffeepot.theme.theme :as theme]
             [coffeepot.firebase :as firebase]))
 
+(firebase/add-auth-listener)
+
 (defn main-panel []
   (let [firebase-app (re-frame/subscribe [::subs/firebase-app])
         listener-alive? (re-frame/subscribe [::subs/auth-listener])

--- a/src/cljs/coffeepot/app.cljs
+++ b/src/cljs/coffeepot/app.cljs
@@ -12,31 +12,8 @@
             [coffeepot.components.common :as c]
             [coffeepot.views.front.core :as front]
             [coffeepot.views.coffee.core :as coffee]
-            [coffeepot.localization :refer [localize-with-substitute]]
-            [coffeepot.theme.theme :as theme]))
-
-(defn add-auth-listener []
-  (debug "Adding auth listener!")
-  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])
-        listener-alive? (re-frame/subscribe [::subs/auth-listener])]
-    (if (and (not @listener-alive?) (some? @firebase-app))
-      (do
-        (re-frame/dispatch [::events/change-auth-listener-status true])
-        (.onAuthStateChanged
-         (.auth @firebase-app)
-         (fn auth-state-changed [user-obj]
-           (if (nil? user-obj)
-            (do
-              (re-frame/dispatch [::events/user-uid nil])
-              (re-frame/dispatch [::events/current-view :logged-out]))
-            (do
-              (re-frame/dispatch [::events/user-uid (.-uid user-obj)])
-              (re-frame/dispatch [::events/current-view :logged-in])
-              (events/get-username! (.-uid user-obj))
-              (events/get-user-description! (.-uid user-obj)))))
-         (fn auth-error [error]
-           (debug error))))
-      (debug "Firebase app not present or listener already active!"))))
+            [coffeepot.theme.theme :as theme]
+            [coffeepot.firebase :as firebase]))
 
 (defn main-panel []
   (let [firebase-app (re-frame/subscribe [::subs/firebase-app])
@@ -45,7 +22,7 @@
         username (re-frame/subscribe [::subs/username])]
     (fn []
       (if (false? @listener-alive?)
-        (add-auth-listener))
+        (firebase/add-auth-listener))
       (if (some? @firebase-app)
         (cond
           (and (some? @user-uid) (some? @username)) [ui/mui-theme-provider {:mui-theme theme/coffeepot-theme} [coffee/app-main]]

--- a/src/cljs/coffeepot/core.cljs
+++ b/src/cljs/coffeepot/core.cljs
@@ -4,7 +4,8 @@
             [taoensso.timbre :as timbre :refer-macros [debug info warn error]]
             [coffeepot.app :as app]
             [coffeepot.config :as config]
-            [coffeepot.events :as events]))
+            [coffeepot.events :as events]
+            [coffeepot.firebase :as firebase]))
 
 (defn timbre-setup []
   (timbre/set-level! :info))
@@ -25,5 +26,5 @@
   (debug "Attemptin to initialize")
   (debug "Let's get things started.")
   (re-frame/dispatch-sync [::events/initialize-db])
-  (re-frame/dispatch [::events/initialize-firebase])
+  (firebase/initialize-firebase)
   (mount-root))

--- a/src/cljs/coffeepot/events.cljs
+++ b/src/cljs/coffeepot/events.cljs
@@ -24,15 +24,10 @@
  (fn [db  [_ locale]]
    (assoc db :locale locale)))
 
-(def firebase-config
-   #js {:apiKey "AIzaSyABjP8bTTvEfy1n_pgR8oiqFBCn6hr4CP8"
-        :authDomain "coffeepot-d13ea.firebaseapp.com"
-        :databaseURL "https://coffeepot-d13ea.firebaseio.com"})
-
 (re-frame/reg-event-db
- ::initialize-firebase
- (fn [db [_]]
-   (assoc db :firebase-app  (js/firebase.initializeApp firebase-config))))
+ ::firebase
+ (fn [db [_ firebase]]
+   (assoc db :firebase-app firebase)))
 
 (re-frame/reg-event-db
   ::current-view
@@ -43,11 +38,6 @@
   ::sub-view
   (fn [db  [_ sub-view]]
     (assoc db :sub-view sub-view)))
-
-(defn db-ref [path] 
-  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])
-        fire-db (.database @firebase-app)]
-    (.ref fire-db (str "/" path))))
 
 (re-frame/reg-event-db
  ::user-uid
@@ -63,47 +53,3 @@
   ::user-description
   (fn [db [_ description]]
     (assoc db :user-description description)))
-
-(defn get-username! [uid]
-    (.once (db-ref (str "users/" uid "/username"))
-      "value"
-      (fn received-db [snapshot]
-        (re-frame/dispatch [::username (.val snapshot)]))))
-
-(defn get-user-description! [uid]
-  (.once (db-ref (str "users/" uid "/description"))
-    "value"
-    (fn received-db [snapshot]
-      (re-frame/dispatch [::user-description (.val snapshot)]))))
-
-(defn save-username-uid [uid username]
- (.set (db-ref (str "users/" uid "/username")) username)
- (.set (db-ref (str "usernames/" username)) #js {:created (js/Date.now)})
-  (re-frame/dispatch [::username username]))
-
-(defn save-user-description [uid description]
-  (.set (db-ref (str "users/" uid "/description")) description)
-  (re-frame/dispatch [::user-description description]))
-
-(re-frame/reg-event-db
-  ::get-username!
-  (fn [db [_]]
-    (let [uid (re-frame/subscribe [::subs/user-uid])]
-      (.once (db-ref (str "users/" @uid "/username"))
-        "value"
-        (fn received-db [snapshot]
-          (assoc db :username (.val snapshot)))))))
-
-(defn listen-firebase-db [path f]
-  (let [ref (db-ref path)
-        a (r/atom nil)]
-    (.on ref "value" (fn [x]
-                        (reset! a (.val x))))
-    (r/create-class
-      {:display-name "listener"
-        :component-will-unmount
-        (fn will-unmount-listener [this]
-          (.off ref))
-        :reagent-render
-        (fn render-listener [args]
-          (into [f a] args))})))

--- a/src/cljs/coffeepot/firebase.cljs
+++ b/src/cljs/coffeepot/firebase.cljs
@@ -13,12 +13,12 @@
 (defn initialize-firebase []
   (re-frame/dispatch [::events/firebase (js/firebase.initializeApp firebase-config)]))
 
-(def providers []
-  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
-    {:google (new (.auth.GoogleAuthProvider @firebase))}))
+(def providers
+  {:google (new js/firebase.auth.GoogleAuthProvider)})
 
 (defn signInWithProvider [provider]
-  (.signInWithPopup (.auth @firebase-app) (provider firebase/providers)))
+  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
+    (.signInWithPopup (.auth @firebase-app) (provider providers))))
 
 (defn logout-auth []
   (debug "logging out")

--- a/src/cljs/coffeepot/firebase.cljs
+++ b/src/cljs/coffeepot/firebase.cljs
@@ -13,6 +13,10 @@
 (defn initialize-firebase []
   (re-frame/dispatch [::events/firebase (js/firebase.initializeApp firebase-config)]))
 
+(def providers []
+  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
+    {:google (new (.auth.GoogleAuthProvider @firebase))}))
+
 (defn logout-auth []
   (debug "logging out")
   (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]

--- a/src/cljs/coffeepot/firebase.cljs
+++ b/src/cljs/coffeepot/firebase.cljs
@@ -1,0 +1,86 @@
+(ns coffeepot.firebase
+  (:require [re-frame.core :as re-frame]
+            [coffeepot.subs :as subs]
+            [reagent.core :as r]
+            [taoensso.timbre :as timbre :refer-macros [debug info warn error]]
+            [coffeepot.events :as events]))
+
+(def firebase-config
+   #js {:apiKey "AIzaSyABjP8bTTvEfy1n_pgR8oiqFBCn6hr4CP8"
+        :authDomain "coffeepot-d13ea.firebaseapp.com"
+        :databaseURL "https://coffeepot-d13ea.firebaseio.com"})
+
+(defn initialize-firebase []
+  (re-frame/dispatch [::events/firebase (js/firebase.initializeApp firebase-config)]) )
+
+(defn db-ref [path]
+  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])
+        fire-db (.database @firebase-app)]
+    (.ref fire-db (str "/" path))))
+
+(defn get-username! [uid]
+    (.once (db-ref (str "users/" uid "/username"))
+      "value"
+      (fn received-db [snapshot]
+        (re-frame/dispatch [::events/username (.val snapshot)]))))
+
+(defn get-user-description! [uid]
+  (.once (db-ref (str "users/" uid "/description"))
+    "value"
+    (fn received-db [snapshot]
+      (re-frame/dispatch [::events/user-description (.val snapshot)]))))
+
+(defn get-username-current-user! []
+  (let [uid (re-frame/subscribe [::subs/user-uid])]
+    (.once (db-ref (str "users/" @uid "/username"))
+           "value"
+           (fn received-db [snapshot]
+             (re-frame/dispatch [::events/username (.val snapshot)])))))
+
+(defn save-username-uid! [uid username]
+ (.set (db-ref (str "users/" uid "/username")) username)
+ (.set (db-ref (str "usernames/" username)) #js {:created (js/Date.now)})
+  (re-frame/dispatch [::events/username username]))
+
+(defn save-user-description! [uid description]
+  (.set (db-ref (str "users/" uid "/description")) description)
+  (re-frame/dispatch [::events/user-description description]))
+
+
+
+(defn listen-firebase-db [path f]
+  (let [ref (db-ref path)
+        a (r/atom nil)]
+    (.on ref "value" (fn [x]
+                        (reset! a (.val x))))
+    (r/create-class
+      {:display-name "listener"
+        :component-will-unmount
+        (fn will-unmount-listener [this]
+          (.off ref))
+        :reagent-render
+        (fn render-listener [args]
+          (into [f a] args))})))
+
+(defn add-auth-listener []
+  (debug "Adding auth listener!")
+  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])
+        listener-alive? (re-frame/subscribe [::subs/auth-listener])]
+    (if (and (not @listener-alive?) (some? @firebase-app))
+      (do
+        (re-frame/dispatch [::events/change-auth-listener-status true])
+        (.onAuthStateChanged
+         (.auth @firebase-app)
+         (fn auth-state-changed [user-obj]
+           (if (nil? user-obj)
+            (do
+              (re-frame/dispatch [::events/user-uid nil])
+              (re-frame/dispatch [::events/current-view :logged-out]))
+            (do
+              (re-frame/dispatch [::events/user-uid (.-uid user-obj)])
+              (re-frame/dispatch [::events/current-view :logged-in])
+              (get-username! (.-uid user-obj))
+              (get-user-description! (.-uid user-obj)))))
+         (fn auth-error [error]
+           (debug error))))
+      (debug "Firebase app not present or listener already active!"))))

--- a/src/cljs/coffeepot/firebase.cljs
+++ b/src/cljs/coffeepot/firebase.cljs
@@ -11,7 +11,16 @@
         :databaseURL "https://coffeepot-d13ea.firebaseio.com"})
 
 (defn initialize-firebase []
-  (re-frame/dispatch [::events/firebase (js/firebase.initializeApp firebase-config)]) )
+  (re-frame/dispatch [::events/firebase (js/firebase.initializeApp firebase-config)]))
+
+(defn logout-auth []
+  (debug "logging out")
+  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
+    (.signOut (.auth @firebase-app))
+    (re-frame/dispatch [::events/sub-view ""])
+    (re-frame/dispatch [::events/user-uid nil])
+    (re-frame/dispatch [::events/username nil])
+    (re-frame/dispatch [::events/user-description nil])))
 
 (defn db-ref [path]
   (let [firebase-app (re-frame/subscribe [::subs/firebase-app])

--- a/src/cljs/coffeepot/firebase.cljs
+++ b/src/cljs/coffeepot/firebase.cljs
@@ -17,6 +17,9 @@
   (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
     {:google (new (.auth.GoogleAuthProvider @firebase))}))
 
+(defn signInWithProvider [provider]
+  (.signInWithPopup (.auth @firebase-app) (provider firebase/providers)))
+
 (defn logout-auth []
   (debug "logging out")
   (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]

--- a/src/cljs/coffeepot/views/coffee/core.cljs
+++ b/src/cljs/coffeepot/views/coffee/core.cljs
@@ -11,17 +11,9 @@
             [coffeepot.events :as events]
             [coffeepot.subs :as subs]
             [coffeepot.views.signup.core :as signup]
+            [coffeepot.firebase :as firebase]
             [coffeepot.localization :refer [localize localize-with-substitute]]
             [coffeepot.components.styles :as styles]))
-
-(defn logout-auth []
-  (debug "logging out")
-  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
-    (.signOut (.auth @firebase-app))
-    (re-frame/dispatch [::events/sub-view ""])
-    (re-frame/dispatch [::events/user-uid nil])
-    (re-frame/dispatch [::events/username nil])
-    (re-frame/dispatch [::events/user-description nil])))
 
 (defn app-main []
   (let [username (re-frame/subscribe [::subs/username])
@@ -41,8 +33,8 @@
                                   :search (fn []
                                             ["Paulig" "Juhla Mokka" "Brazil" "Kulta Katriina"])}
                     :rightmost-buttons [{:label (localize :logout)
-                                        :on-click (fn login-click [e]
-                                                    (logout-auth))}]]
+                                        :on-click (fn logout-click [e]
+                                                    (firebase/logout-auth))}]]
                   [c/app-content
                    [signup/user-description-modal]
                    [c/no-brews]

--- a/src/cljs/coffeepot/views/signup/core.cljs
+++ b/src/cljs/coffeepot/views/signup/core.cljs
@@ -14,19 +14,12 @@
               [coffeepot.components.styles :as styles]
               [coffeepot.firebase :as firebase]))
 
-(defn logout-auth []
-  (debug "logging out")
-  (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
-    (re-frame/dispatch [::events/user-uid nil])
-    (re-frame/dispatch [::events/username nil])
-    (.signOut (.auth @firebase-app))))
-
 (defn provider []
   (new js/firebase.auth.GoogleAuthProvider))
 
 (defn abort-sign-up! []
   (re-frame/dispatch [::events/sub-view ""])
-  (logout-auth))
+  (firebase/logout-auth))
 
 (def register-form
   (fn []

--- a/src/cljs/coffeepot/views/signup/core.cljs
+++ b/src/cljs/coffeepot/views/signup/core.cljs
@@ -14,9 +14,6 @@
               [coffeepot.components.styles :as styles]
               [coffeepot.firebase :as firebase]))
 
-(defn provider []
-  (new js/firebase.auth.GoogleAuthProvider))
-
 (defn abort-sign-up! []
   (re-frame/dispatch [::events/sub-view ""])
   (firebase/logout-auth))
@@ -48,7 +45,7 @@
       [ui/card
        (if (nil? @user-uid)
          [ui/card-header [ui/flat-button {:on-click (fn [] (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
-                                                             (.signInWithPopup (.auth @firebase-app) (provider)))) :label (localize-with-substitute :signup-with (localize :google))} ]]
+                                                             (.signInWithPopup (.auth @firebase-app) (:google firebase/providers)))) :label (localize-with-substitute :signup-with (localize :google))} ]]
          [ui/card-header (localize :authenticated)])])))
 
 (def register-username-step

--- a/src/cljs/coffeepot/views/signup/core.cljs
+++ b/src/cljs/coffeepot/views/signup/core.cljs
@@ -45,7 +45,7 @@
       [ui/card
        (if (nil? @user-uid)
          [ui/card-header [ui/flat-button {:on-click (fn [] (let [firebase-app (re-frame/subscribe [::subs/firebase-app])]
-                                                             (.signInWithPopup (.auth @firebase-app) (:google firebase/providers)))) :label (localize-with-substitute :signup-with (localize :google))} ]]
+                                                             (firebase/signInWithProvider :google))) :label (localize-with-substitute :signup-with (localize :google))} ]]
          [ui/card-header (localize :authenticated)])])))
 
 (def register-username-step

--- a/src/cljs/coffeepot/views/signup/core.cljs
+++ b/src/cljs/coffeepot/views/signup/core.cljs
@@ -11,7 +11,8 @@
               [coffeepot.events :as events]
               [coffeepot.subs :as subs]
               [coffeepot.localization :refer [localize localize-with-substitute]]
-              [coffeepot.components.styles :as styles]))
+              [coffeepot.components.styles :as styles]
+              [coffeepot.firebase :as firebase]))
 
 (defn logout-auth []
   (debug "logging out")
@@ -37,14 +38,14 @@
          {:on-change #(reset! new-username (-> % .-target .-value))}]]
        [ui/card-text (localize :link-auth-username)]
        [ui/card-actions
-        [events/listen-firebase-db (str "usernames/")
+        [firebase/listen-firebase-db (str "usernames/")
          (fn [usernames]
            (if (some? @usernames)
              (if (empty? (filter #(= % @new-username) (js/Object.keys @usernames)))
                (do
                  [ui/card-text (localize :no-username-found)]
                  [ui/flat-button {:on-click (fn []
-                                              (events/save-username-uid @user-uid @new-username)
+                                              (firebase/save-username-uid! @user-uid @new-username)
                                               (re-frame/dispatch [::events/sub-view ""])) :label (localize :save-username)}])
                [ui/card-text (localize :username-warning)])))]]])))
 
@@ -85,11 +86,11 @@
         [:input.form-control
          {:on-change #(reset! new-user-description (-> % .-target .-value))}]]
        [ui/flat-button {:on-click (fn []
-                                    (events/save-user-description @user-uid @new-user-description)) :label (localize :save-description)}]
+                                    (firebase/save-user-description! @user-uid @new-user-description)) :label (localize :save-description)}]
        (if (nil? @user-description)
          [ui/flat-button {:on-click
                           (fn [] (re-frame/dispatch [::events/user-description ""])
-                            (events/save-user-description @user-uid "")) :label (localize :maybe-later)}])])))
+                            (firebase/save-user-description! @user-uid "")) :label (localize :maybe-later)}])])))
 
 (def sign-up-form
   (let [user-uid (re-frame/subscribe [::subs/user-uid])


### PR DESCRIPTION
Cleans up the code a lot and makes it easier to understand what namespace does what. Now you can look to firebase.cljs for all the firebase-database calls, authentications and such.