### PR TITLE
Refines project startup procedures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pom.xml.asc
 /config/dev.cljs
 /config/prod.cljs
 /src/cljs/coffeepot/envconfig.cljs
+package.json

--- a/README.md
+++ b/README.md
@@ -123,7 +123,18 @@ To deploy the database rules set in database_rules.json to Firebase
 
 ### Testing
 #### Cypress testing
-  >$ lein npm run cypress
+All test related code can be found in the folder cypress
+##### Initial folder structure
+- fixtures: Contains data to be used in tests
+- integration: Tests related to integration with other systems, like firebase authentication
+- plugins: to load plugins if needed
+- support: supporting functionality for tests
+
+##### Running tests
+To start the UI for running cypress tests, run the cypress script defined in project.clj
+> $ lein npm run cypress
+
+When prompted for a project, choose the root folder for the coffeepot repository. It will automatically look for the cypress folder and list all the tests for you. You can now run tests one by one or all of them. Have fun with test driven development!
   
 ### Code analysis
 #### Kibit

--- a/config/README.md
+++ b/config/README.md
@@ -3,21 +3,23 @@
 Coffeepot uses environmental configs that for example makes it possible to have a firebase account for development and a separate account for test/prod etc.
 
 In order to use the development configs and run the application locally one must first initialize app for development with init-dev.sh script and then start the app with start-coffeepot.sh script.
-  > init-dev.sh script copies developers own configs (dev.cljs) from the config folder to /src/cljs/coffeepot as envconfig.cljs
-  > start-coffeepot.sh starts coffeepot app after verifying that env config file exists
+
+* init-dev.sh script copies developers own configs (dev.cljs) from the config folder to /src/cljs/coffeepot as envconfig.cljs
+* start-coffeepot.sh starts coffeepot app after verifying that env config file exists
 
 ## Firebase
 
 Set up environmental config for development usage:
 
-- In config folder, create a file named dev.cljs
-  > coffeepot/config/dev.cljs
-- Add the following line declaring the namespace to the top of the file
- ``(ns coffeepot.envconfig)``
-- Add the following def with the map to the file:
- ``(def firebase {:apiKey "your-api-key"
+- In config folder, run the script create-dev-config.sh which will
+  - In config folder, create a file named dev.cljs
+  - Add the following line declaring the namespace to the top of the file
+    ``(ns coffeepot.envconfig)``
+  - Add the following def with the map to the file:
+    ``(def firebase {:apiKey "your-api-key"
                   :authDomain "your-auth-domain"
                   :databaseURL "your-database-url"})``
 - Replace placeholders with your Firebase account details
+  - Go to your project in [firebase console](https://console.firebase.google.com)
 - Initialize dev environment with init-dev.sh
 - Start coffeepot with start-coffeepot.sh

--- a/config/create-dev-config.sh
+++ b/config/create-dev-config.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+currentFolder=$(basename "$PWD")
+configFolderName=config
+devConfigFileName=dev.cljs
+
+if [ $currentFolder != $configFolderName  ]
+then
+    echo "Please run this command in the ${configFolderName} folder".
+else
+    if [ -f $devConfigFileName ]
+    then
+        echo "${devConfigFileName} found, remove it first if you want a fresh start."
+    else
+        echo "${devConfigFileName} not found, creating a boilerplate for you!"
+        touch dev.cljs
+        echo -e '(ns coffeepot.envconfig) \n' > dev.cljs
+        echo -e '(def firebase {:apiKey "your-api-key" :authDomain "your-auth-domain" :databaseUrl "your-database-url"})' >> dev.cljs
+    fi
+fi

--- a/init-dev.sh
+++ b/init-dev.sh
@@ -1,9 +1,10 @@
 #! /bin/bash
-# First checks that the config file for dev environment exists and then copies it to src/cljs/coffeepot
+# First checks that the config folder can be found and the file for dev environment exists and then copies it to src/cljs/coffeepot
 config=./config/dev.cljs
-if [ -e "$config" ]; then
+if [ -d "config"  ] && [ -e "$config" ] ; then
     echo "Dev config found. Copying it to coffeepot."
     cp config/dev.cljs src/cljs/coffeepot/envconfig.cljs
 else
     echo "Dev config not found. Please add your own env config."
+    echo "Or you did not run this script at the root folder of the repository."
 fi


### PR DESCRIPTION
Started the project fresh on a combination of windows 10 ubuntu bash and commandline. Bash was used for everything else, but commandline was needed to run cypress because of bash X-limitations.

Overall the instructions in the main readme and the script-files directed be through the path to development quite nicely.