### PR TITLE
Setups new profile settings page for logged in users

### DIFF
--- a/cypress/integration/user_profile_page.js
+++ b/cypress/integration/user_profile_page.js
@@ -10,6 +10,8 @@ const loginUser = (email, password) => {
 
 const profilePageLinkId = '#profile-page-link'
 const profilePageHeader = '#profile-page-header'
+const profilePageUsernameId = '#profile-page-username'
+const profilePageDescriptionId = '#profile-page-description'
 
 describe('Logged in user', () => {
 
@@ -25,6 +27,20 @@ describe('Logged in user', () => {
     cy.get(profilePageLinkId).click()
     cy.get(profilePageHeader).should('be.visible')
   })
+})
 
+describe('Profile page', () => {
 
+  beforeEach(() => {
+    loginUser('nakki@noemail.com', 'nakkitest')
+    cy.get(profilePageLinkId).click()
+  })
+
+  it('contains username', () => {
+    cy.get(profilePageUsernameId).should('be.visible')
+  })
+
+  it('contains user description', () => {
+    cy.get(profilePageDescriptionId).should('be.visible')
+  })
 })

--- a/cypress/integration/user_profile_page.js
+++ b/cypress/integration/user_profile_page.js
@@ -1,0 +1,21 @@
+import config from '../fixtures/config.js'
+
+const loginUser = (email, password) => {
+  cy.visit(config.devHostAddress)
+  cy.get('#sign-in').click()
+  cy.get('#email-address-input').type(email)
+  cy.get('#email-password-input').type(password)
+  cy.get('#email-sign-in').click()
+}
+
+describe('Logged in user', () => {
+
+  beforeEach(() => {
+    loginUser('nakki@noemail.com', 'nakkitest')
+  })
+
+  it('can see profile page link', () => {
+    cy.get('#profile-page-link').should('be.visible')
+  })
+
+})

--- a/cypress/integration/user_profile_page.js
+++ b/cypress/integration/user_profile_page.js
@@ -8,6 +8,9 @@ const loginUser = (email, password) => {
   cy.get('#email-sign-in').click()
 }
 
+const profilePageLinkId = '#profile-page-link'
+const profilePageHeader = '#profile-page-header'
+
 describe('Logged in user', () => {
 
   beforeEach(() => {
@@ -15,7 +18,13 @@ describe('Logged in user', () => {
   })
 
   it('can see profile page link', () => {
-    cy.get('#profile-page-link').should('be.visible')
+    cy.get(profilePageLinkId).should('be.visible')
   })
+
+  it('can access profile page', () => {
+    cy.get(profilePageLinkId).click()
+    cy.get(profilePageHeader).should('be.visible')
+  })
+
 
 })

--- a/src/cljs/coffeepot/localization.cljs
+++ b/src/cljs/coffeepot/localization.cljs
@@ -52,6 +52,7 @@
                       :hello "Tervehdys {1}"
                       :welcome-coffeepot "Tervetuloa käyttämään Coffeepottia"
                       :profile-page-link "Asetuksesi"
+                      :profile-page-header "Hallinnoi tiliäsi"
                       }
                  :en {
                       :app-title "Coffeepot"
@@ -101,6 +102,7 @@
                       :hello "Hello {1}"
                       :welcome-coffeepot "Welcome to Coffeepot."
                       :profile-page-link "Your settings"
+                      :profile-page-header "Manage your account"
                       }
                  :tongue/fallback :fi
                  })

--- a/src/cljs/coffeepot/localization.cljs
+++ b/src/cljs/coffeepot/localization.cljs
@@ -51,6 +51,7 @@
                       :next "Seuraava"
                       :hello "Tervehdys {1}"
                       :welcome-coffeepot "Tervetuloa käyttämään Coffeepottia"
+                      :profile-page-link "Asetuksesi"
                       }
                  :en {
                       :app-title "Coffeepot"
@@ -99,6 +100,7 @@
                       :next "Next"
                       :hello "Hello {1}"
                       :welcome-coffeepot "Welcome to Coffeepot."
+                      :profile-page-link "Your settings"
                       }
                  :tongue/fallback :fi
                  })

--- a/src/cljs/coffeepot/localization.cljs
+++ b/src/cljs/coffeepot/localization.cljs
@@ -53,6 +53,7 @@
                       :welcome-coffeepot "Tervetuloa käyttämään Coffeepottia"
                       :profile-page-link "Asetuksesi"
                       :profile-page-header "Hallinnoi tiliäsi"
+                      :user-description "Vapaa kuvauksesi"
                       }
                  :en {
                       :app-title "Coffeepot"
@@ -103,6 +104,7 @@
                       :welcome-coffeepot "Welcome to Coffeepot."
                       :profile-page-link "Your settings"
                       :profile-page-header "Manage your account"
+                      :user-description "Personal description"
                       }
                  :tongue/fallback :fi
                  })

--- a/src/cljs/coffeepot/views/coffee/core.cljs
+++ b/src/cljs/coffeepot/views/coffee/core.cljs
@@ -34,7 +34,10 @@
                      :search-field {:placeholder (localize :search)
                                     :search (fn []
                                               ["Paulig" "Juhla Mokka" "Brazil" "Kulta Katriina"])}
-                     :rightmost-buttons [{:label (localize :logout)
+                     :rightmost-buttons [{:id "profile-page-link"
+                                          :label (localize :profile-page-link)
+                                          :on-click (js/console.log "We should be going now!")}
+                                         {:label (localize :logout)
                                           :on-click (fn logout-click [e]
                                                       (firebase/logout-auth))}]]
                     [c/app-content

--- a/src/cljs/coffeepot/views/coffee/core.cljs
+++ b/src/cljs/coffeepot/views/coffee/core.cljs
@@ -13,11 +13,13 @@
             [coffeepot.views.signup.core :as signup]
             [coffeepot.firebase :as firebase]
             [coffeepot.localization :refer [localize localize-with-substitute]]
-            [coffeepot.components.styles :as styles]))
+            [coffeepot.components.styles :as styles]
+            [coffeepot.views.profile.core :as profile-page]))
 
 (defn app-main []
   (let [username (re-frame/subscribe [::subs/username])
-        description (re-frame/subscribe [::subs/user-description])]
+        description (re-frame/subscribe [::subs/user-description])
+        show-profile? (r/atom false)]
     (fn []
       (cond
         (some? @username)
@@ -36,13 +38,14 @@
                                               ["Paulig" "Juhla Mokka" "Brazil" "Kulta Katriina"])}
                      :rightmost-buttons [{:id "profile-page-link"
                                           :label (localize :profile-page-link)
-                                          :on-click (js/console.log "We should be going now!")}
+                                          :on-click #(reset! show-profile? true)}
                                          {:label (localize :logout)
                                           :on-click (fn logout-click [e]
                                                       (firebase/logout-auth))}]]
                     [c/app-content
                      [signup/user-description-modal]
                      [c/no-brews]
+                     [profile-page/profile-modal show-profile?]
                      [re-com/box
                       :attr {:id "description-box"}
                       :class "just-a-test"

--- a/src/cljs/coffeepot/views/profile/core.cljs
+++ b/src/cljs/coffeepot/views/profile/core.cljs
@@ -1,0 +1,27 @@
+(ns coffeepot.views.profile.core
+  (:require [re-frame.core :as re-frame]
+            [re-com.core :as re-com]
+  ;;          [reagent.core :as r]
+    ;;        [cljsjs.material-ui]
+     ;;       [cljs-react-material-ui.reagent :as ui]
+      ;;      [cljs-react-material-ui.icons :as ic]
+
+           [taoensso.timbre :as timbre :refer-macros [debug info warn error]]
+      ;;      [coffeepot.components.common :as c]
+         ;;   [coffeepot.components.navheader :as nav]
+        ;;    [coffeepot.events :as events]
+       ;;     [coffeepot.subs :as subs]
+       ;;     [coffeepot.views.signup.core :as signup]
+       ;;     [coffeepot.firebase :as firebase]
+            [coffeepot.localization :refer [localize localize-with-substitute]]
+       ;;     [coffeepot.components.styles :as styles]
+            ))
+
+(defn profile-modal [show?]
+  (fn [show?]
+    [re-com/v-box
+     :min-height "100vh"
+     :children [(when @show?
+                  [re-com/modal-panel
+                   :backdrop-on-click #(reset! show? false)
+                   :child [:h1 {:id "profile-page-header"} (localize :profile-page-header)]])]]))

--- a/src/cljs/coffeepot/views/profile/core.cljs
+++ b/src/cljs/coffeepot/views/profile/core.cljs
@@ -1,27 +1,32 @@
 (ns coffeepot.views.profile.core
   (:require [re-frame.core :as re-frame]
             [re-com.core :as re-com]
-  ;;          [reagent.core :as r]
-    ;;        [cljsjs.material-ui]
-     ;;       [cljs-react-material-ui.reagent :as ui]
-      ;;      [cljs-react-material-ui.icons :as ic]
-
-           [taoensso.timbre :as timbre :refer-macros [debug info warn error]]
-      ;;      [coffeepot.components.common :as c]
-         ;;   [coffeepot.components.navheader :as nav]
-        ;;    [coffeepot.events :as events]
-       ;;     [coffeepot.subs :as subs]
-       ;;     [coffeepot.views.signup.core :as signup]
-       ;;     [coffeepot.firebase :as firebase]
+            ;;          [reagent.core :as r]
+            ;;        [cljsjs.material-ui]
+            ;;       [cljs-react-material-ui.reagent :as ui]
+            ;;      [cljs-react-material-ui.icons :as ic]
+            [taoensso.timbre :as timbre :refer-macros [debug info warn error]]
+            ;;      [coffeepot.components.common :as c]
+            ;;   [coffeepot.components.navheader :as nav]
+            ;;    [coffeepot.events :as events]
+            [coffeepot.subs :as subs]
+            ;;     [coffeepot.views.signup.core :as signup]
+            ;;     [coffeepot.firebase :as firebase]
             [coffeepot.localization :refer [localize localize-with-substitute]]
-       ;;     [coffeepot.components.styles :as styles]
+            ;;     [coffeepot.components.styles :as styles]
             ))
 
 (defn profile-modal [show?]
-  (fn [show?]
-    [re-com/v-box
-     :min-height "100vh"
-     :children [(when @show?
-                  [re-com/modal-panel
-                   :backdrop-on-click #(reset! show? false)
-                   :child [:h1 {:id "profile-page-header"} (localize :profile-page-header)]])]]))
+  (let [username (re-frame/subscribe [::subs/username])
+        description (re-frame/subscribe [::subs/user-description])]
+    (fn [show?]
+      [re-com/v-box
+       :min-height "100vh"
+       :children [(when @show?
+                    [re-com/modal-panel
+                     :backdrop-on-click #(reset! show? false)
+                     :child [re-com/v-box
+                             :width "300px"
+                             :children [[:h1 {:id "profile-page-header"} (localize :profile-page-header)]
+                                        [:p {:id "profile-page-username"} (str (localize :username) ": " @username)]
+                                        [:p {:id "profile-page-description"} (str (localize :user-description) ": " @description)]]]])]])))


### PR DESCRIPTION
A new modal is now accessible for logged in users that contains their profile settings.

Follows the storyline from trello, this one adds the static username and description. Basic cypress tests included.